### PR TITLE
Default to the ClamAV Mirror provided in OCP4 Silver cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Image of ClamAV](https://www.clamav.net/assets/clamav-trademark.png)
-# ClamAV 
+# ClamAV [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 ClamAV® is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 
@@ -14,4 +14,5 @@ Freshclam can be run within the container at any time to update the existing sig
 The templates in the [openshift/templates](./openshift/templates) will build and deploy the app.  Modify to suit your own environment.  [openshift/templates/clamav-bc.conf](./openshift/templates/clamav-bc.conf) will create your builder image (ideally in your tools project), and [openshift/templates/clamav-dc.conf](./openshift/templates/clamav-dc.conf) will create the pod deployment.  Modify the environment variables defined in both the build config and deployment config appropriately.
 
 ## Getting Help or Reporting an Issue
+
 To report bugs/issues/feature requests, please file an [issue](../../issues).

--- a/config/freshclam.conf
+++ b/config/freshclam.conf
@@ -66,6 +66,9 @@ DatabaseOwner clamupdate
 # Default: current.cvd.clamav.net
 #DNSDatabaseInfo current.cvd.clamav.net
 
+# Use the ClamAV Mirror provided in OCP4 Silver cluster
+DatabaseMirror https://clamav-mirror.apps.silver.devops.gov.bc.ca
+
 # Uncomment the following line and replace XY with your country
 # code. See http://www.iana.org/cctld/cctld-whois.htm for the full list.
 # You can use db.XY.ipv6.clamav.net for IPv6 connections.

--- a/openshift/templates/clamav-bc.conf
+++ b/openshift/templates/clamav-bc.conf
@@ -28,16 +28,7 @@
         "completionDeadlineSeconds": 1800,
         "triggers": [
           {
-            "type": "ImageChange"
-          },
-          {
-            "type": "ImageChange",
-            "imageChange": {
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${NAME}:latest"
-              }
-            }
+            "type": "ConfigChange"
           }
         ],
         "source": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Default to the ClamAV Mirror provided in OCP4 Silver cluster
  - This will default to using the cluster mirror by default, but can still fall back to the upstream ones should it be unavailable.
- Change buildconfig to only trigger on ConfigChange (#4)
- Add project lifecycle badges to top level readme (#8)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
