### PR TITLE
Clamav version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 LABEL name="ubi8-clamav" \
       vendor="Red Hat" \
-      version="0.1.0" \
+      version="0.2.0" \
       release="1" \
       summary="UBI 9 ClamAV" \
       description="ClamAV for UBI 9" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,15 @@ LABEL name="ubi8-clamav" \
       description="ClamAV for UBI 9" \
       maintainer="EPIC"
 
-RUN yum -y update \
-  && yum -y install yum-utils \
-  && rpm --import http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9 \
-  && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN yum install -y clamav-server clamav-data clamav-update clamav-filesystem clamav clamav-scanner-systemd clamav-devel clamav-lib clamav-server-systemd
-RUN yum install -y nc
-RUN yum install -y wget
+RUN yum -y update
+RUN yum -y install https://www.clamav.net/downloads/production/clamav-1.0.1.linux.x86_64.rpm
+RUN yum -y install nc wget
 
-COPY config/clamd.conf /etc/clamd.conf
-COPY config/freshclam.conf /etc/freshclam.conf
+# copy our configs to where clamav expects
+COPY config/clamd.conf /usr/local/etc/clamd.conf
+COPY config/freshclam.conf /usr/local/etc/freshclam.conf
 
-RUN mkdir /opt/app-root
-RUN mkdir /opt/app-root/src
+RUN mkdir -p /opt/app-root/src
 RUN chown -R 1001:0 /opt/app-root/src
 RUN chmod -R ug+rwx /opt/app-root/src
 
@@ -41,4 +37,4 @@ USER 1001
 
 EXPOSE 3310
 
-CMD freshclam && clamd -c /etc/clamd.conf
+CMD freshclam && clamd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi
 
 LABEL name="ubi8-clamav" \
       vendor="Red Hat" \
       version="0.1.0" \
       release="1" \
-      summary="UBI 8 ClamAV" \
-      description="ClamAV for UBI 8" \
+      summary="UBI 9 ClamAV" \
+      description="ClamAV for UBI 9" \
       maintainer="EPIC"
 
 RUN yum -y update \
   && yum -y install yum-utils \
-  && rpm --import http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 \
-  && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+  && rpm --import http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9 \
+  && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN yum install -y clamav-server clamav-data clamav-update clamav-filesystem clamav clamav-scanner-systemd clamav-devel clamav-lib clamav-server-systemd
 RUN yum install -y nc
 RUN yum install -y wget


### PR DESCRIPTION
This PR proposes changing the docker build to include,

* Base image upgraded from ubi8 to ubi9
* Change ClamAV version from 0.103.8 to 1.0.1. 
* Changes install location from EPEL (community maintained) to clamav.net site download link. This change is to address the issue that EPEL only contains version 0.103.8. See [EPEL8](https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/c/) and [EPEL9](https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/c/) packages. The 1.x version is where new features are being added, for example the next [RC](https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.1.0-rc)